### PR TITLE
docs(polymorphic_has_many): Update notable_type attribute

### DIFF
--- a/guides/concepts/resources.md
+++ b/guides/concepts/resources.md
@@ -1323,7 +1323,7 @@ Which means the following filters are required:
 {% highlight ruby %}
 class NoteResource < ApplicationResource
   attribute :notable_id, :integer, only: [:filterable]
-  attribute :notable_type, :string, only: [:filterable]
+  attribute :notable_type, :string_enum, only: [:filterable], allow: ['Employee']
   # ... code ...
 end
 {% endhighlight %}


### PR DESCRIPTION
Had a conversation with Lee that can be found -> (https://graphiti-api.slack.com/archives/C5A4UEMGS/p1606923424312700).

Specifying the `_type` attribute of a `polymorphic_has_many` as a `string_enum` rather than a `string` will ensure that `eql` is used instead of `eq` when making database queries.  This ensures that the database query does not use LOWER and bypass indexes.